### PR TITLE
Change Statement Into Two Actions

### DIFF
--- a/aws_artifacts/IAM_Policy/GCStackPolicy.json
+++ b/aws_artifacts/IAM_Policy/GCStackPolicy.json
@@ -1,18 +1,23 @@
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "VisualEditor0",
-            "Effect": "Allow",
-            "Action": [
-                      "organizations:List*",
-                      "organizations:EnableAWSServiceAccess",
-                      "organizations:DescribeOrganization",
-                      "organizations:DescribeOrganizationalUnit",
-                      "cloudformation:CreateStackSet",
-                      "cloudformation:CreateStackInstances"
-            ],
-            "Resource": "*"
-        }
-    ]
+  "Statement": [
+    {
+      "Action": [
+        "organizations:List*",
+        "organizations:EnableAWSServiceAccess",
+        "organizations:DescribeOrganization",
+        "organizations:DescribeOrganizationalUnit"
+      ],
+      "Resource": "*",
+      "Effect": "Allow",
+      "Sid": "GCSplunkStackSet1"
+    },
+    {
+      "Action": [
+        "cloudformation:*"
+      ],
+      "Resource": "arn:aws:cloudformation:*:*:stackset/grandcentral*",
+      "Effect": "Allow",
+      "Sid": "GCSplunkStackSet2"
+    }
+  ]
 }


### PR DESCRIPTION
I have submitted this change to restrict resource for cloudformation action to only the grand central stack sets.   Our implementation engineer needed access to update and delete stacksets, but the resource statement was overly permissive to give with restricting.